### PR TITLE
Fix/use luxon date handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "chart.js": "^4.2.1",
                 "chartjs-adapter-moment": "^1.0.1",
                 "gh-pages": "^5.0.0",
+                "luxon": "^3.3.0",
                 "moment": "^2.29.4",
                 "react": "^18.2.0",
                 "react-chartjs-2": "^5.2.0",
@@ -36,6 +37,7 @@
                 "typescript": "^4.9.5"
             },
             "devDependencies": {
+                "@types/luxon": "^3.2.0",
                 "faker": "^5.5.3",
                 "prettier": "2.8.4",
                 "react-scripts": "5.0.1"
@@ -4615,6 +4617,12 @@
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+            "dev": true
+        },
+        "node_modules/@types/luxon": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
+            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
             "dev": true
         },
         "node_modules/@types/mime": {
@@ -13119,6 +13127,14 @@
             "dev": true,
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/luxon": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+            "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/lz-string": {
@@ -22207,6 +22223,12 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
+        "@types/luxon": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
+            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
+            "dev": true
+        },
         "@types/mime": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -28591,6 +28613,11 @@
             "requires": {
                 "yallist": "^3.0.2"
             }
+        },
+        "luxon": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+            "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
         },
         "lz-string": {
             "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "chart.js": "^4.2.1",
         "chartjs-adapter-moment": "^1.0.1",
         "gh-pages": "^5.0.0",
+        "luxon": "^3.3.0",
         "moment": "^2.29.4",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
@@ -59,6 +60,7 @@
         ]
     },
     "devDependencies": {
+        "@types/luxon": "^3.2.0",
         "faker": "^5.5.3",
         "prettier": "2.8.4",
         "react-scripts": "5.0.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import './App.scss'
 
 // local imports
 import { Range } from "./components/range"
-import { generateDataSets, convertYearsElapsedToDate } from "./models/calculations";
+import { generateDataSets } from "./models/calculations";
 
 // import hooks
 import "chartjs-adapter-moment";
@@ -47,6 +47,8 @@ import { faClipboard } from '@fortawesome/free-solid-svg-icons';
 // import AccordionSummary from '@mui/material/AccordionSummary';
 // import AccordionDetails from '@mui/material/AccordionDetails';
 
+import { DateTime } from "luxon";
+
 ChartJS.register(
     Legend,
     LineElement,
@@ -78,8 +80,8 @@ function App(props: any) {
     const [copiedUrl, setCopiedUrl] = useState(false);
 
     const projections = generateDataSets(fireNumber, currentAge, retireAge, rate / 100, pmtMonthly, principal)
-    const today = new Date()
-    const maxChartDate = convertYearsElapsedToDate(today, retireAge - currentAge);
+    const today = DateTime.now()
+    const maxChartDate = today.plus({ years: retireAge - currentAge });
     const data = {
         datasets: [
             {
@@ -115,7 +117,7 @@ function App(props: any) {
             <Typography variant="body2">
                 Your coast FIRE number is <b>${(projections.postCoastData[0].y).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' '}</b>
                 on {`${projections.result.coastFireDate ?
-                    projections.result.coastFireDate.toLocaleDateString("en-US") : ''} `}
+                    projections.result.coastFireDate.toLocaleString() : ''} `}
 
                 (at age <b>{`${projections.result.coastFireAge ?
                     (projections.result.coastFireAge).toFixed(2) : ''} `}</b>
@@ -323,7 +325,7 @@ function App(props: any) {
                                 scales: {
                                     x: {
                                         type: 'time',
-                                        max: maxChartDate.toISOString()
+                                        max: maxChartDate.toISO()
                                     },
                                     y: {
                                         min: 0,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,7 +159,7 @@ function App(props: any) {
     // warn peope of the difficulties of small phones (like mine)
     const theme = useTheme();
     const topMessage = useMediaQuery(theme.breakpoints.down("xs")) ?
-        "(Dang you have a tiny phone! I want you to know this app is way better on a bigger phone screen)"
+        "(tip: rotate your screen if you want sliders)"
         : <div>I'll let <a href="https://walletburst.com/tools/coast-fire-calc/">this guy</a> explain what Coast FIRE is (and you might like his calculator better)</div>
 
     // TODO: show a stacked area chart of pricipal, contributions, and interest
@@ -195,7 +195,7 @@ function App(props: any) {
                                     <Typography variant="label" >
                                         Current Age:
                                     </Typography>
-                                    <Grid item sx={{ ml: 2 }} xs={2}>
+                                    <Grid item sx={{ ml: 2 }} xs={3}>
                                         <TextField
                                             id="current-age"
                                             size="small"
@@ -334,32 +334,9 @@ function App(props: any) {
                                 }
                             }} data={data} />
                         </div>
-
-                        {/*
-                        TODO: create an accordion of instructions?
-                        <Accordion  >
-                            <AccordionSummary
-                                expandIcon={
-                                    <FontAwesomeIcon icon={faExpandPropIcon} />
-                                }
-                                aria-controls="panel1a-content"
-                                id="panel1a-header"
-                            >
-                                <Typography>Instructions</Typography>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                <Typography>
-                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-                                    malesuada lacus ex, sit amet blandit leo lobortis eget.
-                                </Typography>
-                            </AccordionDetails>
-                        </Accordion>
-                        */}
-
                     </Stack>
                 </Container>
             </ScopedCssBaseline>
-
         </>
     );
 }

--- a/src/components/range/Range.tsx
+++ b/src/components/range/Range.tsx
@@ -31,9 +31,11 @@ function Range(props: IRangeProps) {
     };
 
     // TODO: do something else about this gross sizing (trying to make mobile look good)
-    let textInputSize = 2.5
+    let spaceAfterSlider = 1.5
+    let textInputSize = 2.25
     if (Math.floor(Math.log10(props.maxValue)) > 2) {
-        textInputSize = 4
+        textInputSize = 4.5
+        spaceAfterSlider = 2.5
     }
 
     let startAdornment = ""
@@ -43,7 +45,7 @@ function Range(props: IRangeProps) {
     }
     if (props.format && props.format === "percentage") {
         endAdornment = "%"
-        textInputSize = 3
+        textInputSize = 3.25
     }
 
     const marks = [
@@ -59,11 +61,7 @@ function Range(props: IRangeProps) {
 
     // avoid shenanigans on small screens
     const theme = useTheme();
-    const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
     const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down("xs"));
-    const isMedium = useMediaQuery(theme.breakpoints.down("md"));
-
-    let spaceAfterSlider = isSmallScreen ? 1 : isMedium ? 2 : 2.5
     if (isExtraSmallScreen) {
         textInputSize = 0
     }
@@ -88,9 +86,9 @@ function Range(props: IRangeProps) {
             <Typography variant="label">
                 {props.labelText}:
             </Typography>
-            <Grid container spacing={spaceAfterSlider} alignItems="center" sx={{ pl: 2 }}>
+            <Grid container direction="row" spacing={spaceAfterSlider} sx={{ pl: 2 }}>
                 {slider}
-                <Grid item xs={textInputSize} alignSelf="flex-start">
+                <Grid item xs={textInputSize}>
                     <NumericFormat
                         value={props.state || 0}
                         defaultValue={0}
@@ -105,7 +103,8 @@ function Range(props: IRangeProps) {
                         suffix={endAdornment}
                         sx={{
                             // fontWeight: 'bold',
-                            fontSize: '1rem'
+                            fontSize: '1rem',
+                            pr: 0
                         }}
                         size='small'
                         onFocus={(event) => event.target.select()}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ const defaultTheme = createTheme({
     },
     breakpoints: {
         values: {
-            xs: 400, // where things really break
+            xs: 389, // where things really break, but plenty of phones are ~390px wide
             sm: 475, // this width is when the UI starts disintegrating
             md: 900,
             lg: 1200,


### PR DESCRIPTION
Integrate `luxon` for datetime handling. So far, using native `Date` object for juggling dates has been an absolute mess.

This PR also ensures that the number of dates on the graph (19) will always stay the same.