### PR TITLE
feat: support for barista fire calculations and dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ After some searching, I think [this](https://projectionlab.com/) project kind of
     - [ ] Ensure that the number of datapoints on the timeline stays constant (undid this checkmark, need to investigate further)
 - [ ] Update the chart to be a stacked area graph breaking down contributions, interest, and initial deposit
 - [X] Have a "save as link" feature where you get a URL embedded with current parameters (maybe base64 json) to show your calculations to others
-- [ ] Tooltip for each parameter
+- [X] Tooltip/explanation for each parameter
 - [ ] Explanation of why FIRE is impossible
     - [X] Show all-red graph of current trajectory (instead of not showing anything at all)
 - [X] Show an all-blue graph if already coast FIRE (instead of not showing anything at all)
+- [X] Support for barista FIRE calculations
 - [ ] Figure out a solution to the min/max ranges not meeting all user expectations/situations
 - [ ] iMovie-like "bring your own plan" calculator (might not ever get to this)
 - [ ] Red to green financial retirement spectrum (with info for cursor hover)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ After some searching, I think [this](https://projectionlab.com/) project kind of
 - [ ] Red to green financial retirement spectrum (with info for cursor hover)
 - [ ] Fix icon sizing
 - [ ] Support dark mode
+- [ ] Bug when you prefill an alredy coast fire scenario but then empty out APR
 
 ## Other notes
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ After some searching, I think [this](https://projectionlab.com/) project kind of
 - [ ] iMovie-like "bring your own plan" calculator (might not ever get to this)
 - [ ] Red to green financial retirement spectrum (with info for cursor hover)
 - [ ] Fix icon sizing
-- [ ] Support dark mode
-- [ ] Bug when you prefill an alredy coast fire scenario but then empty out APR
+- [X] Support dark mode
+- [X] fixed ~~Bug when you prefill an alredy coast fire scenario but then empty out APR~~
 
 ## Other notes
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,7 +1,7 @@
 $primary-color: #e91e63;
 
 html {
-    background-color: ghostwhite;
+    /* background-color: ghostwhite; */
     font-size: 14px;
 
     h2 {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 import {
     Alert,
+    Fab,
     Box,
     Button,
     Container,
@@ -183,12 +184,11 @@ function App(props: any) {
     const theme = useTheme();
     const topMessage = useMediaQuery(theme.breakpoints.down("xs")) ?
         "(tip: rotate your screen if you want sliders)"
-        : <div>
-
+        : <Typography variant="body1">
             Watch <a href="https://www.youtube.com/watch?v=V1ategW3cyk">this video</a> {' '}
             and check out <a href="https://walletburst.com/tools/coast-fire-calc/" > this guy's calculator</a> if you're confused
             <br /> <b>Note:</b> Barista FIRE calculator mode is experimental
-        </div >
+        </Typography>
 
     const handleCalculatorMode = (
         event: React.MouseEvent<HTMLElement>,
@@ -200,7 +200,7 @@ function App(props: any) {
     // TODO: show a stacked area chart of pricipal, contributions, and interest
     return (
         <>
-            <ScopedCssBaseline sx={{ backgroundColor: 'ghostwhite' }}>
+            <ScopedCssBaseline>
                 <Container maxWidth="md">
                     <Stack spacing={2} sx={{ m: 2 }}>
                         <Paper sx={{ p: 2 }} elevation={2}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -335,7 +335,7 @@ function App(props: any) {
                                     setState={setFireNumber}
                                     openTipDialog={setOpenTipDialog}
                                     setTipDialogText={setTipDialogText}
-                                    tipDialogText={"FIRE Number is the total value of investments you will need to retire comfortably. Your FIRE number should be large enough for you to comfortably withdraw money from during retirement. If you're following the 4% rule, that means you can withdraw 4% from your total savings each year. Using this rule, if you need $60k a year for retirement, you should aim for save $1.5m by the time you retire: 60,000 x (1/0.04) = 1,500,000."}
+                                    tipDialogText={"FIRE Number is the total value of investments you will need to retire comfortably. Your FIRE number should be large enough for you to comfortably withdraw money from during retirement. If you're following the 4% rule, that means you can withdraw 4% from your total savings each year. Using this rule, if you need $60k a year for retirement, you should aim to save $1.5m by the time you retire: 60,000 x (1/0.04) = 1,500,000."}
                                 />
                                 <Grid item alignSelf="center">
                                     <Alert severity="info" variant="outlined" sx={{ pl: 2, pr: 2, pb: 0, pt: 0 }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -307,7 +307,7 @@ function App(props: any) {
                                     setState={setRetireAge}
                                     openTipDialog={setOpenTipDialog}
                                     setTipDialogText={setTipDialogText}
-                                    tipDialogText={"Retirement Age is the age you plan to fully retire. In other words, the age you plan to start fully withdrawing money from your retirement savings."}
+                                    tipDialogText={"Retirement Age is the age you plan to fully retire. In other words, the age you plan to start fully withdrawing money from your retirement savings and stop working."}
                                 />
                                 <Divider light />
                                 <Range
@@ -321,7 +321,7 @@ function App(props: any) {
                                     setState={setPrincipal}
                                     openTipDialog={setOpenTipDialog}
                                     setTipDialogText={setTipDialogText}
-                                    tipDialogText={"Initial Principal is the total value of your retirement assets today. Only include investement assets (not cash). Do not count home equity unless you plan to turn that into retirement income."}
+                                    tipDialogText={"Initial Principal is the total face value of your retirement assets today. Only include investment assets (not cash). Do not count home equity unless you know what you're doing and you plan to turn that equity into retirement income."}
                                 />
                                 <Divider light />
                                 <Range
@@ -335,7 +335,7 @@ function App(props: any) {
                                     setState={setFireNumber}
                                     openTipDialog={setOpenTipDialog}
                                     setTipDialogText={setTipDialogText}
-                                    tipDialogText={"FIRE Number is the total value of investments you will need in order to retire comfortably. Your FIRE number should be big enough for you to comfortably withdraw money from during retirement. If you're following the 4% rule, that means you can withdraw 4% from your total savings each year. Using this rule, if you need $60k a year for retirement, you should aim for save $1.5m by the time you retire: 60,000 x (1/0.04) = 1,500,000."}
+                                    tipDialogText={"FIRE Number is the total value of investments you will need to retire comfortably. Your FIRE number should be large enough for you to comfortably withdraw money from during retirement. If you're following the 4% rule, that means you can withdraw 4% from your total savings each year. Using this rule, if you need $60k a year for retirement, you should aim for save $1.5m by the time you retire: 60,000 x (1/0.04) = 1,500,000."}
                                 />
                                 <Grid item alignSelf="center">
                                     <Alert severity="info" variant="outlined" sx={{ pl: 2, pr: 2, pb: 0, pt: 0 }}>
@@ -371,14 +371,14 @@ function App(props: any) {
                                     setState={setPmtMonthly}
                                     openTipDialog={setOpenTipDialog}
                                     setTipDialogText={setTipDialogText}
-                                    tipDialogText={"Contributions is the amount you contribute each month to savings during your accumulation period (before achieving coast/barista FIRE). During this period, you should aggressively save toward retirement. Later down the road once you achieve coast/barista FIRE, you can stop contributing this amount (and either save less, save nothing, or start making small withdrawels)."}
+                                    tipDialogText={"Contributions is the amount you contribute each month to savings during your accumulation period (before achieving coast/barista FIRE). During this period, you should aggressively save toward retirement. Later down the road once you achieve coast/barista FIRE, you can stop contributing this amount (and either save less, save nothing, or start making small withdrawals)."}
                                 />
                                 <Divider light />
                                 <Range
                                     disabled={calcMode === "coast"}
                                     labelText="Barista FIRE Contributions (monthly)"
                                     // negative barista "income" has interesting implications
-                                    // i.e. a "soft-retirement" with smaller withdrawels
+                                    // i.e. a "soft-retirement" with smaller withdrawals
                                     minValue={Math.floor(-1 * pmtMonthly)}
                                     maxValue={Math.floor(pmtMonthly)}
                                     defaultValue={0}
@@ -402,7 +402,7 @@ function App(props: any) {
                                     setState={setRate}
                                     openTipDialog={setOpenTipDialog}
                                     setTipDialogText={setTipDialogText}
-                                    tipDialogText={`APR is the expected real rate of return on your investments. In other words, how much do you expect your investments to grow (in ${new Date().getFullYear()} dollars after taking into account taxes and inflation). Some people use 7% as a rule of thumb, but it is always better to exercise caution when choosing a growth rate to build your retirement plans off of. Many will argue that 7% is too optimistic. Others will say that 7% is too conservative.`}
+                                    tipDialogText={`APR is the expected real rate of return on your investments. In other words, what is the growth of your investments (in ${new Date().getFullYear()} dollars) after accounting for taxes and inflation? Some people use 7% as a rule of thumb, but it is always better to exercise caution when choosing a projected growth rate. Many will argue that 7% is too optimistic. Others will say that 7% is too conservative.`}
                                 />
                             </Stack>
                         </Paper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,7 +170,7 @@ function App(props: any) {
     const theme = useTheme();
     const topMessage = useMediaQuery(theme.breakpoints.down("xs")) ?
         "(tip: rotate your screen if you want sliders)"
-        : <div>I'll let <a href="https://walletburst.com/tools/coast-fire-calc/">this guy</a> explain what Coast FIRE is (and you might like his calculator better)</div>
+        : <div>I'll let <a href="https://walletburst.com/tools/coast-fire-calc/">this guy</a> explain what Coast FIRE is (and you might like his calculator better) <br /> <b>Note:</b> Barista FIRE calculator mode is experimental</div>
 
     const handleCalculatorMode = (
         event: React.MouseEvent<HTMLElement>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,7 +281,6 @@ function App(props: any) {
                                     </Grid>
 
                                 </Box>
-
                                 <Divider light />
                                 <Range
                                     labelText="Retirement Age"
@@ -294,25 +293,14 @@ function App(props: any) {
                                 />
                                 <Divider light />
                                 <Range
-                                    labelText="APR (return)"
-                                    minValue={0.01}
-                                    maxValue={15}
-                                    defaultValue={7}
-                                    step={0.01}
-                                    format="percentage"
-                                    state={rate}
-                                    setState={setRate}
-                                />
-                                <Divider light />
-                                <Range
-                                    labelText="Contributions (monthly)"
+                                    labelText="Initial Principal"
                                     minValue={0}
-                                    maxValue={15000}
-                                    defaultValue={1200}
-                                    step={0.01}
+                                    maxValue={fireNumber}
+                                    defaultValue={2000000}
+                                    step={1000}
                                     format="money"
-                                    state={pmtMonthly}
-                                    setState={setPmtMonthly}
+                                    state={principal}
+                                    setState={setPrincipal}
                                 />
                                 <Divider light />
                                 <Range
@@ -346,20 +334,18 @@ function App(props: any) {
                                             </ListItem>
                                         </List>
                                     </Alert>
-
                                 </Grid>
                                 <Divider light />
                                 <Range
-                                    labelText="Initial Principal"
+                                    labelText="Contributions (monthly)"
                                     minValue={0}
-                                    maxValue={fireNumber}
-                                    defaultValue={2000000}
-                                    step={1000}
+                                    maxValue={15000}
+                                    defaultValue={1200}
+                                    step={0.01}
                                     format="money"
-                                    state={principal}
-                                    setState={setPrincipal}
+                                    state={pmtMonthly}
+                                    setState={setPmtMonthly}
                                 />
-
                                 <Divider light />
                                 <Range
                                     disabled={calcMode === "coast"}
@@ -373,6 +359,17 @@ function App(props: any) {
                                     format="money"
                                     state={pmtMonthlyBarista}
                                     setState={setPmtMonthlyBarista}
+                                />
+                                <Divider light />
+                                <Range
+                                    labelText="APR (return)"
+                                    minValue={0.01}
+                                    maxValue={15}
+                                    defaultValue={7}
+                                    step={0.01}
+                                    format="percentage"
+                                    state={rate}
+                                    setState={setRate}
                                 />
                             </Stack>
                         </Paper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,9 +100,14 @@ function App(props: any) {
 
     const coastDateStr = projections.result.coastFireDate ?
         projections.result.coastFireDate.toLocaleString() : ''
-    const baristaAddendum = calcMode === "barista" ? <Typography variant="body2">
-        (After {coastDateStr}, you will be able to retire by <b>{retireAge}</b> as long as you continue saving <b>{`$${(pmtMonthlyBarista).toFixed(2)}`}</b> a month)
-    </Typography> : <></>
+    const baristaAddendum = calcMode === "barista" ?
+        pmtMonthlyBarista > 0 ?
+            <Typography variant="body2">
+                (After {coastDateStr}, you will be able to retire by <b>{retireAge}</b> as long as you continue saving <b>{`$${(pmtMonthlyBarista).toFixed(2)}/mo`}</b>)
+            </Typography> :
+            <Typography variant="body2">
+                (You can still retire by <b>{retireAge}</b> even if you withdraw <b>{`$${(-1 * pmtMonthlyBarista).toFixed(2)}/mo`}</b> from your savings after {coastDateStr})
+            </Typography> : <></>
 
 
     // TODO: maybe add a tool-tip showing the math as to why FIRE is not possible
@@ -194,72 +199,86 @@ function App(props: any) {
                                 </Box>
                                 <Typography alignSelf="center" variant="subtitle1">{topMessage}</Typography>
                                 <Box alignSelf="center">
-                                    <Stack direction="row" alignItems="center" spacing={1}>
-                                        <ToggleButtonGroup
-                                            color="primary"
-                                            value={calcMode}
-                                            exclusive
-                                            onChange={handleCalculatorMode}
-                                            size="small"
-                                        >
-                                            <ToggleButton value="coast">
-                                                Coast FIRE
-                                            </ToggleButton>
-                                            <ToggleButton value="barista">
-                                                Barista FIRE
-                                            </ToggleButton>
-                                        </ToggleButtonGroup>
-
-                                        <Button
-                                            sx={{
-                                                width: "max-content",
-                                                height: "max-content",
-                                                p: 1
-                                            }}
-                                            color="primary"
-                                            variant="contained"
-                                            onClick={onShareClick}
-                                            startIcon={copiedIcon}
-                                            size="small"
-                                        >
-                                            Share as URL
-                                        </Button>
-                                    </Stack>
+                                    <Button
+                                        sx={{
+                                            width: "max-content",
+                                            height: "max-content",
+                                            p: 1
+                                        }}
+                                        color="primary"
+                                        variant="contained"
+                                        onClick={onShareClick}
+                                        startIcon={copiedIcon}
+                                        size="small"
+                                    >
+                                        Share as URL
+                                    </Button>
                                 </Box>
                                 <Divider light />
-                                <Grid container direction="row" alignItems="center">
-                                    <Typography variant="label" >
-                                        Current Age:
-                                    </Typography>
-                                    <Grid item sx={{ ml: 2 }} xs={3}>
-                                        <TextField
-                                            id="current-age"
-                                            size="small"
-                                            inputProps={{
-                                                type: "number",
-                                                inputMode: 'numeric',
-                                                pattern: '[0-9]*'
-                                            }}
-                                            value={currentAge ? currentAge : ''}
-                                            onInput={(e) => {
-                                                const et = e.target as HTMLInputElement;
-                                                // set to zero so that the app does not explode
-                                                const newCurrentAge = parseInt(et.value !== "" ? et.value : "0")
-                                                if (newCurrentAge <= retireAge) {
-                                                    setCurrentAge(newCurrentAge)
-                                                }
-                                            }}
-                                            onBlur={(e) => {
-                                                if (!currentAge) {
-                                                    setCurrentAge(35) // TODO: make this a default value constant
-                                                }
-                                            }}
-                                            sx={{
-                                                fontSize: '1rem'
-                                            }}
-                                        />
+                                <Box alignSelf="center">
+                                    <Grid container direction="row" alignItems="center">
+                                        <Typography variant="label" >
+                                            FIRE Type:
+                                        </Typography>
+                                        <Grid item sx={{ ml: 2 }}>
+                                            <ToggleButtonGroup
+                                                color="primary"
+                                                value={calcMode}
+                                                exclusive
+                                                onChange={handleCalculatorMode}
+                                                size="small"
+                                            >
+                                                <ToggleButton value="coast">
+                                                    Coast FIRE
+                                                </ToggleButton>
+                                                <ToggleButton value="barista">
+                                                    Barista FIRE
+                                                </ToggleButton>
+                                            </ToggleButtonGroup>
+
+                                        </Grid>
                                     </Grid>
-                                </Grid>
+                                </Box>
+
+                                <Divider light />
+
+                                <Box alignSelf="center">
+                                    <Grid container direction="row" alignItems="center">
+                                        <Typography variant="label" >
+                                            Current Age:
+                                        </Typography>
+                                        <Grid item sx={{ ml: 2, width: '6rem' }}>
+                                            <TextField
+                                                id="current-age"
+                                                size="small"
+                                                inputProps={{
+                                                    type: "number",
+                                                    inputMode: 'numeric',
+                                                    pattern: '[0-9]*'
+                                                }}
+                                                value={currentAge ? currentAge : ''}
+                                                onInput={(e) => {
+                                                    const et = e.target as HTMLInputElement;
+                                                    // set to zero so that the app does not explode
+                                                    const newCurrentAge = parseInt(et.value !== "" ? et.value : "0")
+                                                    if (newCurrentAge <= retireAge) {
+                                                        setCurrentAge(newCurrentAge)
+                                                    }
+                                                }}
+                                                onBlur={(e) => {
+                                                    if (!currentAge) {
+                                                        setCurrentAge(35) // TODO: make this a default value constant
+                                                    }
+                                                }}
+                                                sx={{
+                                                    fontSize: '1rem'
+                                                }}
+                                            />
+                                        </Grid>
+                                    </Grid>
+
+                                </Box>
+
                                 <Divider light />
                                 <Range
                                     labelText="Retirement Age"
@@ -344,8 +363,8 @@ function App(props: any) {
                                     labelText="Barista FIRE contributions (monthly)"
                                     // negative barista "income" has interesting implications
                                     // i.e. a "soft-retirement" with smaller withdrawels
-                                    minValue={0}
-                                    maxValue={pmtMonthly}
+                                    minValue={Math.floor(-1 * pmtMonthly)}
+                                    maxValue={Math.floor(pmtMonthly)}
                                     defaultValue={0}
                                     step={0.01}
                                     format="money"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,7 +360,7 @@ function App(props: any) {
                                 <Divider light />
                                 <Range
                                     disabled={calcMode === "coast"}
-                                    labelText="Barista FIRE contributions (monthly)"
+                                    labelText="Barista FIRE Contributions (monthly)"
                                     // negative barista "income" has interesting implications
                                     // i.e. a "soft-retirement" with smaller withdrawels
                                     minValue={Math.floor(-1 * pmtMonthly)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ function App(props: any) {
                 (You can still retire by <b>{retireAge}</b> even if you withdraw <b>{`$${(-1 * pmtMonthlyBarista).toFixed(2)}/mo`}</b> from your savings after {coastDateStr})
             </Typography> :
         <Typography variant="body2">
-            (after {coastDateStr} you can halt all retirement contributions and still retire at {retireAge})
+            (After {coastDateStr} you can halt all retirement contributions and still retire at {retireAge})
         </Typography>
 
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,7 +129,9 @@ function App(props: any) {
                 Your {calcMode} FIRE number is <b>${(projections.postCoastData[0].y).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' '}</b>
                 on {`${coastDateStr} `} at age <b>{`${projections.result.coastFireAge ?
                     (projections.result.coastFireAge).toFixed(2) : ''} `}</b>
-                in <b>{`${((projections.result.coastFireAge ? projections.result.coastFireAge : 0) - currentAge).toFixed(2)} years`}</b>
+                in <b>{`${((projections.result.coastFireAge ? projections.result.coastFireAge : 0) - currentAge).toFixed(2)} years `}</b>
+                <br />
+                (after {coastDateStr} you can halt all retirement contributions and still retire at {retireAge})
             </Typography>
             {baristaAddendum}
         </Alert>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,14 +100,17 @@ function App(props: any) {
 
     const coastDateStr = projections.result.coastFireDate ?
         projections.result.coastFireDate.toLocaleString() : ''
-    const baristaAddendum = calcMode === "barista" ?
+    const summaryAddendum = calcMode === "barista" ?
         pmtMonthlyBarista > 0 ?
             <Typography variant="body2">
                 (After {coastDateStr}, you will be able to retire by <b>{retireAge}</b> as long as you continue saving <b>{`$${(pmtMonthlyBarista).toFixed(2)}/mo`}</b>)
             </Typography> :
             <Typography variant="body2">
                 (You can still retire by <b>{retireAge}</b> even if you withdraw <b>{`$${(-1 * pmtMonthlyBarista).toFixed(2)}/mo`}</b> from your savings after {coastDateStr})
-            </Typography> : <></>
+            </Typography> :
+        <Typography variant="body2">
+            (after {coastDateStr} you can halt all retirement contributions and still retire at {retireAge})
+        </Typography>
 
 
     // TODO: maybe add a tool-tip showing the math as to why FIRE is not possible
@@ -130,10 +133,8 @@ function App(props: any) {
                 on {`${coastDateStr} `} at age <b>{`${projections.result.coastFireAge ?
                     (projections.result.coastFireAge).toFixed(2) : ''} `}</b>
                 in <b>{`${((projections.result.coastFireAge ? projections.result.coastFireAge : 0) - currentAge).toFixed(2)} years `}</b>
-                <br />
-                (after {coastDateStr} you can halt all retirement contributions and still retire at {retireAge})
             </Typography>
-            {baristaAddendum}
+            {summaryAddendum}
         </Alert>
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,11 @@ import {
     Box,
     Button,
     Container,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
     Divider,
     Grid,
     Link,
@@ -39,7 +44,7 @@ import {
     ToggleButtonGroup,
     Typography,
     useMediaQuery,
-    useTheme
+    useTheme,
 } from '@mui/material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
@@ -69,8 +74,8 @@ function App(props: any) {
 
     // setup local state (coast fire parameters)
     const [currentAge, setCurrentAge] = useState(currentAgeParam > -1 ? currentAgeParam : 35);
-    const [retireAge, setRetireAge] = useState(retireAgeParam > -1 ? retireAgeParam : 60);
-    const [pmtMonthly, setPmtMonthly] = useState(pmtParam > -1 ? pmtParam : 4000);
+    const [retireAge, setRetireAge] = useState(retireAgeParam > -1 ? retireAgeParam : 67);
+    const [pmtMonthly, setPmtMonthly] = useState(pmtParam > -1 ? pmtParam : 2500);
     const [rate, setRate] = useState(rateParam > -1 ? rateParam : 7); // default to 7% APR
     const [fireNumber, setFireNumber] = useState(fireNumParam > -1 ? fireNumParam : 2000000);
     const [principal, setPrincipal] = useState(principalParam > -1 ? principalParam : 0);
@@ -78,6 +83,12 @@ function App(props: any) {
 
     const [copiedUrl, setCopiedUrl] = useState(false);
     const [calcMode, setCalcMode] = useState<"coast" | "barista">(pmtMonthlyBarista !== 0 ? "barista" : "coast"); // toggle between coast or barista fire calculations
+    const [tipDialogText, setTipDialogText] = useState("");
+    const [openTipDialog, setOpenTipDialog] = useState(false); // tip dialog
+
+    const handleClose = () => {
+        setOpenTipDialog(false);
+    };
 
     const baristaPmtMonthly = calcMode === "coast" ? 0 : pmtMonthlyBarista
     const projections = generateDataSets(fireNumber, currentAge, retireAge, rate / 100, pmtMonthly, principal, baristaPmtMonthly)
@@ -103,14 +114,14 @@ function App(props: any) {
     const summaryAddendum = calcMode === "barista" ?
         pmtMonthlyBarista > 0 ?
             <Typography variant="body2">
-                (After {coastDateStr}, you will be able to retire by <b>{retireAge}</b> as long as you continue saving <b>{`$${(pmtMonthlyBarista).toFixed(2)}/mo`}</b>)
+                (i.e. after <b>{coastDateStr}</b> you will be able to retire at age <b>{retireAge}</b> as long as you continue saving <b>{`$${(pmtMonthlyBarista).toFixed(2)}/mo`}</b>)
             </Typography> :
             <Typography variant="body2">
-                (You can still retire by <b>{retireAge}</b> even if you withdraw <b>{`$${(-1 * pmtMonthlyBarista).toFixed(2)}/mo`}</b> from your savings after {coastDateStr})
+                (i.e. you can start withdrawing <b>{`$${(-1 * pmtMonthlyBarista).toFixed(2)}/mo`}</b> from savings on <b>{coastDateStr}</b> and still retire at age <b>{retireAge}</b>)
             </Typography> :
         <Typography variant="body2">
-            (After {coastDateStr} you can halt all retirement contributions and still retire at {retireAge})
-        </Typography>
+            (i.e. after <b>{coastDateStr}</b> you can halt all retirement contributions and still retire at age <b>{retireAge}</b >)
+        </Typography >
 
 
     // TODO: maybe add a tool-tip showing the math as to why FIRE is not possible
@@ -129,15 +140,14 @@ function App(props: any) {
     } else if (projections.result.isPossible && !projections.result.alreadyCoastFire) {
         summaryMessage = <Alert variant="outlined" severity="info">
             <Typography variant="body2">
-                Your {calcMode} FIRE number is <b>${(projections.postCoastData[0].y).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' '}</b>
-                on {`${coastDateStr} `} at age <b>{`${projections.result.coastFireAge ?
+                In <b>{`${((projections.result.coastFireAge ? projections.result.coastFireAge : 0) - currentAge).toFixed(2)} years `}</b>
+                you can {calcMode} FIRE once you save up <b>${(projections.postCoastData[0].y).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' '}</b>
+                on <b>{`${coastDateStr} `}</b> at age <b>{`${projections.result.coastFireAge ?
                     (projections.result.coastFireAge).toFixed(2) : ''} `}</b>
-                in <b>{`${((projections.result.coastFireAge ? projections.result.coastFireAge : 0) - currentAge).toFixed(2)} years `}</b>
             </Typography>
             {summaryAddendum}
         </Alert>
     }
-
 
     const faPropIcon = faGithub as IconProp;
     const faClipboardPropIcon = faClipboard as IconProp;
@@ -173,7 +183,12 @@ function App(props: any) {
     const theme = useTheme();
     const topMessage = useMediaQuery(theme.breakpoints.down("xs")) ?
         "(tip: rotate your screen if you want sliders)"
-        : <div>I'll let <a href="https://walletburst.com/tools/coast-fire-calc/">this guy</a> explain what Coast FIRE is (and you might like his calculator better) <br /> <b>Note:</b> Barista FIRE calculator mode is experimental</div>
+        : <div>
+
+            Watch <a href="https://www.youtube.com/watch?v=V1ategW3cyk">this video</a> {' '}
+            and check out <a href="https://walletburst.com/tools/coast-fire-calc/" > this guy's calculator</a> if you're confused
+            <br /> <b>Note:</b> Barista FIRE calculator mode is experimental
+        </div >
 
     const handleCalculatorMode = (
         event: React.MouseEvent<HTMLElement>,
@@ -290,6 +305,9 @@ function App(props: any) {
                                     step={1}
                                     state={retireAge}
                                     setState={setRetireAge}
+                                    openTipDialog={setOpenTipDialog}
+                                    setTipDialogText={setTipDialogText}
+                                    tipDialogText={"Retirement Age is the age you plan to fully retire. In other words, the age you plan to start fully withdrawing money from your retirement savings."}
                                 />
                                 <Divider light />
                                 <Range
@@ -301,6 +319,9 @@ function App(props: any) {
                                     format="money"
                                     state={principal}
                                     setState={setPrincipal}
+                                    openTipDialog={setOpenTipDialog}
+                                    setTipDialogText={setTipDialogText}
+                                    tipDialogText={"Initial Principal is the total value of your retirement assets today. Only include investement assets (not cash). Do not count home equity unless you plan to turn that into retirement income."}
                                 />
                                 <Divider light />
                                 <Range
@@ -312,6 +333,9 @@ function App(props: any) {
                                     format="money"
                                     state={fireNumber}
                                     setState={setFireNumber}
+                                    openTipDialog={setOpenTipDialog}
+                                    setTipDialogText={setTipDialogText}
+                                    tipDialogText={"FIRE Number is the total value of investments you will need in order to retire comfortably. Your FIRE number should be big enough for you to comfortably withdraw money from during retirement. If you're following the 4% rule, that means you can withdraw 4% from your total savings each year. Using this rule, if you need $60k a year for retirement, you should aim for save $1.5m by the time you retire: 60,000 x (1/0.04) = 1,500,000."}
                                 />
                                 <Grid item alignSelf="center">
                                     <Alert severity="info" variant="outlined" sx={{ pl: 2, pr: 2, pb: 0, pt: 0 }}>
@@ -345,6 +369,9 @@ function App(props: any) {
                                     format="money"
                                     state={pmtMonthly}
                                     setState={setPmtMonthly}
+                                    openTipDialog={setOpenTipDialog}
+                                    setTipDialogText={setTipDialogText}
+                                    tipDialogText={"Contributions is the amount you contribute each month to savings during your accumulation period (before achieving coast/barista FIRE). During this period, you should aggressively save toward retirement. Later down the road once you achieve coast/barista FIRE, you can stop contributing this amount (and either save less, save nothing, or start making small withdrawels)."}
                                 />
                                 <Divider light />
                                 <Range
@@ -359,10 +386,13 @@ function App(props: any) {
                                     format="money"
                                     state={pmtMonthlyBarista}
                                     setState={setPmtMonthlyBarista}
+                                    openTipDialog={setOpenTipDialog}
+                                    setTipDialogText={setTipDialogText}
+                                    tipDialogText={"Barista FIRE Contributions is the amount you plan to add (or withdraw) monthly to or from your savings once you achieve barista FIRE. With barista FIRE, you can take a lower paying job, work fewer hours, and even start making small withdrawals from your savings until you achieve true retirement (when you stop working entirely)."}
                                 />
                                 <Divider light />
                                 <Range
-                                    labelText="APR (return)"
+                                    labelText="APR (real return)"
                                     minValue={0.01}
                                     maxValue={15}
                                     defaultValue={7}
@@ -370,6 +400,9 @@ function App(props: any) {
                                     format="percentage"
                                     state={rate}
                                     setState={setRate}
+                                    openTipDialog={setOpenTipDialog}
+                                    setTipDialogText={setTipDialogText}
+                                    tipDialogText={`APR is the expected real rate of return on your investments. In other words, how much do you expect your investments to grow (in ${new Date().getFullYear()} dollars after taking into account taxes and inflation). Some people use 7% as a rule of thumb, but it is always better to exercise caution when choosing a growth rate to build your retirement plans off of. Many will argue that 7% is too optimistic. Others will say that 7% is too conservative.`}
                                 />
                             </Stack>
                         </Paper>
@@ -408,6 +441,24 @@ function App(props: any) {
                         </div>
                     </Stack>
                 </Container>
+                <Dialog
+                    open={openTipDialog}
+                    onClose={handleClose}
+                >
+                    <DialogTitle>
+                        {"Explanation"}
+                    </DialogTitle>
+                    <DialogContent>
+                        <DialogContentText>
+                            {tipDialogText}
+                        </DialogContentText>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={handleClose} autoFocus>
+                            Close
+                        </Button>
+                    </DialogActions>
+                </Dialog>
             </ScopedCssBaseline >
         </>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import {
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 import {
     Alert,
-    Fab,
     Box,
     Button,
     Container,
@@ -184,9 +183,9 @@ function App(props: any) {
     const theme = useTheme();
     const topMessage = useMediaQuery(theme.breakpoints.down("xs")) ?
         "(tip: rotate your screen if you want sliders)"
-        : <Typography variant="body1">
-            Watch <a href="https://www.youtube.com/watch?v=V1ategW3cyk">this video</a> {' '}
-            and check out <a href="https://walletburst.com/tools/coast-fire-calc/" > this guy's calculator</a> if you're confused
+        : <Typography variant="subtitle2">
+            Watch <Link href="https://www.youtube.com/watch?v=V1ategW3cyk">this video</Link> {' '}
+            and check out <Link href="https://walletburst.com/tools/coast-fire-calc/" > this guy's calculator</Link> if you're confused
             <br /> <b>Note:</b> Barista FIRE calculator mode is experimental
         </Typography>
 
@@ -209,7 +208,7 @@ function App(props: any) {
                                     <Stack direction="row" justifyContent="center" alignItems="center" spacing={1}>
                                         <h2>Coast FIRE Calculator</h2>
                                         <Link sx={{
-                                            color: 'black',
+                                            color: props.theme === 'light' ? 'black' : 'white',
                                         }} href="https://github.com/BradyBolton/coast-fire-calculator">
                                             <FontAwesomeIcon id="gh-icon" icon={faPropIcon} size="xl" />
                                         </Link>
@@ -394,7 +393,7 @@ function App(props: any) {
                                 <Divider light />
                                 <Range
                                     labelText="APR (real return)"
-                                    minValue={0.01}
+                                    minValue={0}
                                     maxValue={15}
                                     defaultValue={7}
                                     step={0.01}
@@ -421,21 +420,31 @@ function App(props: any) {
                                 plugins: {
                                     legend: {
                                         position: "top",
+                                        labels: {
+                                            color: props.theme === 'light' ? '#212121' : 'white'
+                                        }
                                     },
                                     title: {
                                         display: true,
                                         text: "Coast FIRE Projections",
+                                        color: props.theme === 'light' ? '#212121' : 'white'
                                     },
                                 },
                                 scales: {
                                     x: {
                                         type: 'time',
                                         min: projections.xMin.toISO(),
-                                        max: projections.xMax.toISO()
+                                        max: projections.xMax.toISO(),
+                                        ticks: {
+                                            color: props.theme === 'light' ? '#212121' : 'white'
+                                        }
                                     },
                                     y: {
                                         min: projections.yMin,
-                                        max: projections.yMax
+                                        max: projections.yMax,
+                                        ticks: {
+                                            color: props.theme === 'light' ? '#212121' : 'white'
+                                        }
                                     }
                                 }
                             }} data={data} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -379,8 +379,9 @@ function App(props: any) {
                                     labelText="Barista FIRE Contributions (monthly)"
                                     // negative barista "income" has interesting implications
                                     // i.e. a "soft-retirement" with smaller withdrawals
-                                    minValue={Math.floor(-1 * pmtMonthly)}
-                                    maxValue={Math.floor(pmtMonthly)}
+                                    // caps are based off of theoretical withdrawal limits of 4% rule (otherwise the purpose of coast/barista fire is defeated)
+                                    minValue={Math.floor(-1 * fireNumber * 0.04 / 12)}
+                                    maxValue={Math.floor(fireNumber * 0.04 / 12)}
                                     defaultValue={0}
                                     step={0.01}
                                     format="money"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ function App(props: any) {
     const rateParam: number = parseFloat(currentUrl.searchParams.get('r') ?? "-1")
     const fireNumParam: number = parseFloat(currentUrl.searchParams.get('fn') ?? "-1")
     const principalParam: number = parseFloat(currentUrl.searchParams.get('p') ?? "-1")
-    const pmtBaristaParam: number = parseFloat(currentUrl.searchParams.get('pmtb') ?? "-1")
+    const pmtBaristaParam: number = parseFloat(currentUrl.searchParams.get('pmtb') ?? "0")
 
     // setup local state (coast fire parameters)
     const [currentAge, setCurrentAge] = useState(currentAgeParam > -1 ? currentAgeParam : 35);
@@ -74,10 +74,10 @@ function App(props: any) {
     const [rate, setRate] = useState(rateParam > -1 ? rateParam : 7); // default to 7% APR
     const [fireNumber, setFireNumber] = useState(fireNumParam > -1 ? fireNumParam : 2000000);
     const [principal, setPrincipal] = useState(principalParam > -1 ? principalParam : 0);
-    const [pmtMonthlyBarista, setPmtMonthlyBarista] = useState(pmtBaristaParam > -1 ? pmtBaristaParam : 0);
+    const [pmtMonthlyBarista, setPmtMonthlyBarista] = useState(pmtBaristaParam);
 
     const [copiedUrl, setCopiedUrl] = useState(false);
-    const [calcMode, setCalcMode] = useState<"coast" | "barista">(pmtMonthlyBarista > 0 ? "barista" : "coast"); // toggle between coast or barista fire calculations
+    const [calcMode, setCalcMode] = useState<"coast" | "barista">(pmtMonthlyBarista !== 0 ? "barista" : "coast"); // toggle between coast or barista fire calculations
 
     const baristaPmtMonthly = calcMode === "coast" ? 0 : pmtMonthlyBarista
     const projections = generateDataSets(fireNumber, currentAge, retireAge, rate / 100, pmtMonthly, principal, baristaPmtMonthly)

--- a/src/components/range/Range.tsx
+++ b/src/components/range/Range.tsx
@@ -1,5 +1,18 @@
-import { TextField, Grid, Typography, Slider, Box, useMediaQuery, useTheme } from '@mui/material'
+import {
+    IconButton,
+    Box,
+    Grid,
+    Slider,
+    TextField,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material'
 import { NumericFormat } from 'react-number-format'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons';
+
 
 import React from 'react'
 
@@ -14,10 +27,15 @@ interface IRangeProps {
     format?: RangeFormat;
     state: number
     setState: React.Dispatch<React.SetStateAction<number>>
+    openTipDialog: React.Dispatch<React.SetStateAction<boolean>>
+    setTipDialogText: React.Dispatch<React.SetStateAction<string>>
+    tipDialogText: string
     disabled?: boolean
 }
 
 function Range(props: IRangeProps) {
+
+    const faCircleQuestionProp = faCircleQuestion as IconProp;
 
     const handleSliderChange = (event: Event, value: number | number[]) => {
         props.setState(value as number)
@@ -96,7 +114,13 @@ function Range(props: IRangeProps) {
     return (
         <Box>
             <Typography variant="label">
-                {props.labelText}:
+                {props.labelText}
+                <IconButton size="small" onClick={() => {
+                    props.setTipDialogText(props.tipDialogText)
+                    props.openTipDialog(true)
+                }}>
+                    <FontAwesomeIcon icon={faCircleQuestionProp} size="sm" />
+                </IconButton>
             </Typography>
             <Grid container direction="row" spacing={spaceAfterSlider} sx={{ pl: 2 }}>
                 {slider}

--- a/src/components/range/Range.tsx
+++ b/src/components/range/Range.tsx
@@ -31,11 +31,16 @@ function Range(props: IRangeProps) {
         }
     };
 
+    const theme = useTheme();
+    const isMediumScreen = useMediaQuery(theme.breakpoints.down("md"));
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+    const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down("xs"));
+
     // TODO: do something else about this gross sizing (trying to make mobile look good)
     let spaceAfterSlider = 1.5
-    let textInputSize = 2.25
+    let textInputSize = isMediumScreen ? 2.5 : 1.5
     if (Math.floor(Math.log10(props.maxValue)) > 2) {
-        textInputSize = 4.5
+        textInputSize = isExtraSmallScreen ? 4.5 : isSmallScreen ? 4.5 : isMediumScreen ? 3.75 : 2
         spaceAfterSlider = 2.5
     }
 
@@ -46,7 +51,7 @@ function Range(props: IRangeProps) {
     }
     if (props.format && props.format === "percentage") {
         endAdornment = "%"
-        textInputSize = 3.25
+        textInputSize = isMediumScreen ? 3.5 : 1.5
     }
 
     let marks = [
@@ -68,8 +73,6 @@ function Range(props: IRangeProps) {
     }
 
     // avoid shenanigans on small screens
-    const theme = useTheme();
-    const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down("xs"));
     if (isExtraSmallScreen) {
         textInputSize = 0
     }

--- a/src/components/range/Range.tsx
+++ b/src/components/range/Range.tsx
@@ -14,6 +14,7 @@ interface IRangeProps {
     format?: RangeFormat;
     state: number
     setState: React.Dispatch<React.SetStateAction<number>>
+    disabled?: boolean
 }
 
 function Range(props: IRangeProps) {
@@ -78,6 +79,7 @@ function Range(props: IRangeProps) {
             step={props.step}
             valueLabelDisplay="auto"
             marks={marks}
+            disabled={props.disabled}
         />
     </Grid> : <></>
 
@@ -90,6 +92,7 @@ function Range(props: IRangeProps) {
                 {slider}
                 <Grid item xs={textInputSize}>
                     <NumericFormat
+                        disabled={props.disabled}
                         value={props.state || 0}
                         defaultValue={0}
                         thousandSeparator=","

--- a/src/components/range/Range.tsx
+++ b/src/components/range/Range.tsx
@@ -49,7 +49,7 @@ function Range(props: IRangeProps) {
         textInputSize = 3.25
     }
 
-    const marks = [
+    let marks = [
         {
             value: props.minValue,
             label: props.minValue.toLocaleString(),
@@ -59,6 +59,13 @@ function Range(props: IRangeProps) {
             label: props.maxValue.toLocaleString(),
         },
     ];
+
+    if (props.minValue < 0) {
+        marks.push({
+            value: 0,
+            label: "0"
+        })
+    }
 
     // avoid shenanigans on small screens
     const theme = useTheme();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ const root = ReactDOM.createRoot(
 
 const getDesignTokens = (mode: PaletteMode) => ({
     palette: {
-        mode: mode, // TODO: support dark mode (value could be 'dark')
+        mode: mode,
         ...(mode === 'light'
             ? {
                 // palette values for light mode
@@ -96,9 +96,6 @@ const AppWrapper: FC = () => {
     // Update the theme only if the mode changes
     // @ts-ignore
     const theme = useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
-
-    // TODO: track dark mode via global state (perhaps using easy-peasy)
-    // const defaultTheme = createTheme();
 
     return (
         <ThemeProvider theme={theme}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,7 @@ const defaultTheme = createTheme({
         subtitle1: {
             color: 'slategrey',
             fontSize: '1rem',
+            textAlign: "center"
             // fontWeight: 'bold'
         }
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import React, { FC, useMemo, useState } from "react";
 import ReactDOM from "react-dom/client";
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { pink, yellow, grey } from '@mui/material/colors';
+import { pink, grey } from '@mui/material/colors';
 import { PaletteMode, Fab } from '@mui/material';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -24,29 +24,27 @@ const root = ReactDOM.createRoot(
 const getDesignTokens = (mode: PaletteMode) => ({
     palette: {
         mode: mode, // TODO: support dark mode (value could be 'dark')
-        // primary: pink,
-        // secondary: yellow,
         ...(mode === 'light'
             ? {
                 // palette values for light mode
                 primary: pink,
-                divider: yellow[200],
+                divider: pink[200],
                 text: {
                     primary: grey[900],
-                    secondary: grey[800],
+                    secondary: grey[900],
                 },
             }
             : {
                 // palette values for dark mode
                 primary: pink,
-                divider: yellow[700],
+                divider: pink[700],
                 background: {
                     default: grey[900],
                     paper: grey[900],
                 },
                 text: {
-                    primary: '#e8e8e8',
-                    secondary: '#e8e8e8',
+                    primary: '#ffffff',
+                    secondary: '#ffffff',
                 },
             }),
     },
@@ -71,10 +69,15 @@ const getDesignTokens = (mode: PaletteMode) => ({
             fontSize: '1rem',
         },
         subtitle1: {
-            color: 'slategrey',
+            color: 'secondary',
             fontSize: '1rem',
             textAlign: "center"
             // fontWeight: 'bold'
+        },
+        subtitle2: {
+            color: 'secondary',
+            fontSize: '1.1rem',
+            fontWeight: 400,
         }
     },
 });
@@ -85,7 +88,7 @@ const AppWrapper: FC = () => {
     const faSunProp = faSun as IconProp;
     const faMoonProp = faMoon as IconProp;
 
-    const [mode, setMode] = useState<PaletteMode>('dark');
+    const [mode, setMode] = useState<PaletteMode>('light');
 
     const colorMode = useMemo(
         () => ({
@@ -127,7 +130,7 @@ const AppWrapper: FC = () => {
             >
                 {mode === "dark" ? <FontAwesomeIcon icon={faSunProp} size="lg" /> : <FontAwesomeIcon icon={faMoonProp} size="lg" />}
             </Fab>
-            <App />
+            <App theme={mode} />
         </ThemeProvider>
     )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,23 +5,50 @@ import "./index.css";
 import App from "./App";
 
 // import libraries
-import React from "react";
+import React, { FC, useMemo, useState } from "react";
 import ReactDOM from "react-dom/client";
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { pink } from '@mui/material/colors';
-import { yellow } from '@mui/material/colors';
+import { pink, yellow, grey } from '@mui/material/colors';
+import { PaletteMode, Fab } from '@mui/material';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
+
 
 const root = ReactDOM.createRoot(
     document.getElementById("root") as HTMLElement
 );
 
-// TODO: track dark mode via global state (perhaps using easy-peasy)
-const defaultTheme = createTheme({
+const getDesignTokens = (mode: PaletteMode) => ({
     palette: {
-        mode: 'light', // TODO: support dark mode (value could be 'dark')
-        primary: pink,
-        secondary: yellow,
+        mode: mode, // TODO: support dark mode (value could be 'dark')
+        // primary: pink,
+        // secondary: yellow,
+        ...(mode === 'light'
+            ? {
+                // palette values for light mode
+                primary: pink,
+                divider: yellow[200],
+                text: {
+                    primary: grey[900],
+                    secondary: grey[800],
+                },
+            }
+            : {
+                // palette values for dark mode
+                primary: pink,
+                divider: yellow[700],
+                background: {
+                    default: grey[900],
+                    paper: grey[900],
+                },
+                text: {
+                    primary: '#e8e8e8',
+                    secondary: '#e8e8e8',
+                },
+            }),
     },
     breakpoints: {
         values: {
@@ -52,12 +79,63 @@ const defaultTheme = createTheme({
     },
 });
 
+
+const AppWrapper: FC = () => {
+
+    const faSunProp = faSun as IconProp;
+    const faMoonProp = faMoon as IconProp;
+
+    const [mode, setMode] = useState<PaletteMode>('dark');
+
+    const colorMode = useMemo(
+        () => ({
+            // The dark mode switch would invoke this method
+            toggleColorMode: () => {
+                setMode((prevMode: PaletteMode) =>
+                    prevMode === 'light' ? 'dark' : 'light',
+                );
+            },
+        }),
+        [],
+    );
+
+    // Update the theme only if the mode changes
+    // @ts-ignore
+    const theme = useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
+
+    // TODO: track dark mode via global state (perhaps using easy-peasy)
+    // const defaultTheme = createTheme();
+
+    return (
+        <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <Fab sx={{
+                margin: 0,
+                right: 20,
+                top: 20,
+                left: 'auto',
+                position: 'fixed',
+            }}
+                onClick={() => {
+                    setMode((prevMode: PaletteMode) =>
+                        prevMode === 'light' ? 'dark' : 'light',
+                    );
+                }}
+                color="primary"
+                aria-label="add"
+                size="small"
+            >
+                {mode === "dark" ? <FontAwesomeIcon icon={faSunProp} size="lg" /> : <FontAwesomeIcon icon={faMoonProp} size="lg" />}
+            </Fab>
+            <App />
+        </ThemeProvider>
+    )
+}
+
+
 // import CssBaseline to remove some browswer inconsistencies
 root.render(
     <React.StrictMode>
-        <ThemeProvider theme={defaultTheme}>
-            <CssBaseline />
-            <App />
-        </ThemeProvider>
+        <AppWrapper />
     </React.StrictMode>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,9 @@ const getDesignTokens = (mode: PaletteMode) => ({
                     primary: grey[900],
                     secondary: grey[900],
                 },
+                background: {
+                    default: '#f2f2f2'
+                }
             }
             : {
                 // palette values for dark mode
@@ -89,18 +92,6 @@ const AppWrapper: FC = () => {
     const faMoonProp = faMoon as IconProp;
 
     const [mode, setMode] = useState<PaletteMode>('light');
-
-    const colorMode = useMemo(
-        () => ({
-            // The dark mode switch would invoke this method
-            toggleColorMode: () => {
-                setMode((prevMode: PaletteMode) =>
-                    prevMode === 'light' ? 'dark' : 'light',
-                );
-            },
-        }),
-        [],
-    );
 
     // Update the theme only if the mode changes
     // @ts-ignore

--- a/src/models/calculations.test.ts
+++ b/src/models/calculations.test.ts
@@ -26,6 +26,15 @@ it('compound interest with contributions', () => {
     expect(Math.abs(fv - expected)).toBeLessThan(epsilon);
 });
 
+// 0 interest rate
+it('no compound interest with contributions and principal', () => {
+    // stacking 500/mo in cash for 10 years, no interest
+    const pmt = pmtMonthlyToDaily(500)
+    const fv = futureValueSeries(pmt, 0, 365, 10, 500)
+    const expected = 60500
+    expect(Math.abs(fv - expected)).toBeLessThan(epsilon);
+});
+
 // calculate coast fire scenario for someone contributing $3070 per month, 
 // 0 pricipal for 12.2 years at 7% APR compounded daily
 it('calculate coast fire date successfully', () => {
@@ -95,27 +104,27 @@ it('calculate datapoints of accumulation phase', () => {
     // both the 'x' and 'y' values if we used dependency injection)
     const expectedPreCoastValues = [
         0,
-        53080.70696295287,
-        111770.050604734,
-        176490.76995464208,
-        247825.07003303213,
-        326652.38124900963,
-        413556.41738648433,
-        509422.18698339653,
-        615298.2151632777,
-        731979.9605696297, // <- approximate coast number
+        53085.24029631768,
+        111775.05287378076,
+        176491.95474191985,
+        247831.1593998274,
+        326659.10045653314,
+        413560.6269551159,
+        509429.0204452079,
+        615307.2406895051,
+        731999.8218920437, // <- approximate coast number
     ]
     const expectedPostCoastValues = [
-        731979.9605696297, // <- post coast begins at approximate coast fire date
-        818206.8051920788,
-        914773.8357560807,
-        1022569.3620559797,
-        1143197.687580515,
-        1278110.8288341898,
-        1428671.5952278373,
-        1597287.3690478806,
-        1785521.7229659478,
-        1996154.3995112309, // <- approximate fire date
+        731999.8218920437, // <- post coast begins at approximate coast fire date
+        818222.4684609286,
+        914798.6569521059,
+        1022590.7819789144,
+        1143219.5722832766,
+        1278135.296234613,
+        1428704.0317885152,
+        1597317.946575876,
+        1785555.9429217286,
+        1996208.5625597467, // <- approximate fire date
     ]
 
     const preCoastValues = result.preCoastData.map((x) => {

--- a/src/models/calculations.ts
+++ b/src/models/calculations.ts
@@ -101,11 +101,12 @@ const calculateCoastFire = (fireNumber: number, currentAge: number, retirementAg
     const pmt = pmtMonthlyToDaily(pmtMonthly)
     const pmtBarista = pmtMonthlyToDaily(pmtMonthlyBarista)
 
-    if (futureValue(principal, rate, 365, retirementAge - currentAge) >= fireNumber
-        || futureValueSeries(pmtBarista, rate, 365, retirementAge - currentAge, principal) >= fireNumber) {
+    // check if coast/barista FIRE has already been achieved:
+    // (account for a sufficiently reckless barista withdrawal rate sabotaging an otherwise workable coast FIRE scenario)
+    if (futureValueSeries(pmtBarista, rate, 365, retirementAge - currentAge, principal) >= fireNumber) {
         return {
             isPossible: true,
-            alreadyCoastFire: true,
+            alreadyCoastFire: true, // also counts as barista FIRE if |pmtBarista| > 0
             coastFireNumber: undefined,
             coastFireAge: undefined,
             finalAmount: undefined,

--- a/src/models/calculations.ts
+++ b/src/models/calculations.ts
@@ -36,7 +36,10 @@ const futureValue = (p: number, r: number, n: number, t: number): number => {
 // futureValueSeries calculates the future value of a series of payments
 // reference: https://www.thecalculatorsite.com/articles/finance/future-value-formula.php 
 const futureValueSeries = (pmt: number, r: number, n: number, t: number, p: number = 0): number => {
-    return pmt * ((Math.pow(1 + (r / n), n * t) - 1) / (r / n)) + futureValue(p, r, n, t)
+    if (r > 0) {
+        return pmt * ((Math.pow(1 + (r / n), n * t) - 1) / (r / n)) + futureValue(p, r, n, t)
+    }
+    return p + (pmt * n * t) // no interest accumulation
 }
 
 // pmtMonthlyToDaily is a quick helper function to average out monthly payments per day

--- a/src/models/calculations.ts
+++ b/src/models/calculations.ts
@@ -48,7 +48,7 @@ const pmtMonthlyToDaily = (monthlyPmt: number): number => {
 // note: convergence won't work if coast fire is technically impossible (returning a mostly undefined result)
 const convergeCoastFire = (iterations: number,
     fireNumber: number, currentAge: number, retirementAge: number,
-    pmt: number, min: number, max: number, rate: number, principal: number = 0,
+    pmt: number, min: number, max: number, rate: number, principal: number = 0, pmtBarista: number = 0,
     coastFireResult: CoastFireResult | undefined): CoastFireResult => {
 
     const today: DateTime = DateTime.now()
@@ -74,7 +74,7 @@ const convergeCoastFire = (iterations: number,
         const numSavingYears = min + (i * step)
         const coastAmount = futureValueSeries(pmt, rate, 365, numSavingYears, principal)
         const numCoastingYears = retirementAge - numSavingYears - currentAge
-        const finalAmount = futureValue(coastAmount, rate, 365, numCoastingYears)
+        const finalAmount = futureValueSeries(pmtBarista, rate, 365, numCoastingYears, coastAmount)
 
         if (finalAmount > fireNumber) {
             const newMin = min + ((i - 1) * step)
@@ -87,7 +87,7 @@ const convergeCoastFire = (iterations: number,
                 coastFireDate: today.plus({ years: numSavingYears }),
                 finalAmount: finalAmount
             }
-            return convergeCoastFire(iterations - 1, fireNumber, currentAge, retirementAge, pmt, newMin, newMax, rate, principal, newResult)
+            return convergeCoastFire(iterations - 1, fireNumber, currentAge, retirementAge, pmt, newMin, newMax, rate, principal, pmtBarista, newResult)
         }
     }
 
@@ -95,8 +95,14 @@ const convergeCoastFire = (iterations: number,
 }
 
 // calculate the coast fire amount and age necessary to retire at a given age with a given retirement goal at some rate of return
-const calculateCoastFire = (fireNumber: number, currentAge: number, retirementAge: number, rate: number, monthlyContribution: number, principal: number = 0): CoastFireResult => {
-    if (futureValue(principal, rate, 365, retirementAge - currentAge) >= fireNumber) {
+const calculateCoastFire = (fireNumber: number, currentAge: number, retirementAge: number, rate: number,
+    pmtMonthly: number, principal: number = 0, pmtMonthlyBarista: number = 0): CoastFireResult => {
+
+    const pmt = pmtMonthlyToDaily(pmtMonthly)
+    const pmtBarista = pmtMonthlyToDaily(pmtMonthlyBarista)
+
+    if (futureValue(principal, rate, 365, retirementAge - currentAge) >= fireNumber
+        || futureValueSeries(pmtBarista, rate, 365, retirementAge - currentAge, principal) >= fireNumber) {
         return {
             isPossible: true,
             alreadyCoastFire: true,
@@ -107,18 +113,16 @@ const calculateCoastFire = (fireNumber: number, currentAge: number, retirementAg
         }
     }
 
-    const pmt = pmtMonthlyToDaily(monthlyContribution)
-
     // TODO: make compounding period a parameter
     const yearsTilRetirement = retirementAge - currentAge
     for (let i = 1; i < (yearsTilRetirement + 1); i++) {
         const coastAmount = futureValueSeries(pmt, rate, 365, i, principal)
         const numCoastYears = retirementAge - i - currentAge
-        const finalAmount = futureValue(coastAmount, rate, 365, numCoastYears)
+        const finalAmount = futureValueSeries(pmtBarista, rate, 365, numCoastYears, coastAmount)
 
         if (finalAmount > fireNumber) {
             // hard-coded 3 iterations to converge toward coast fire data
-            return convergeCoastFire(3, fireNumber, currentAge, retirementAge, pmt, i - 1, i, rate, principal, undefined)
+            return convergeCoastFire(3, fireNumber, currentAge, retirementAge, pmt, i - 1, i, rate, principal, pmtBarista, undefined)
         }
     }
 
@@ -165,9 +169,9 @@ const getDatesFormatted = (startDate: DateTime, stopDate: DateTime, numDates: nu
 
 // Return the value for the outer data field used to paint the line chart
 const generateDataSets = (fireNumber: number, currentAge: number, retirementAge: number,
-    rate: number, monthlyContribution: number, principal: number = 0): CoastFireData => {
+    rate: number, pmtMonthly: number, principal: number = 0, pmtMonthlyBarista: number = 0): CoastFireData => {
 
-    const result = calculateCoastFire(fireNumber, currentAge, retirementAge, rate, monthlyContribution, principal)
+    const result = calculateCoastFire(fireNumber, currentAge, retirementAge, rate, pmtMonthly, principal, pmtMonthlyBarista)
 
     const today = DateTime.now()
     const daysTilFire = ((retirementAge - currentAge) * 365)
@@ -203,7 +207,7 @@ const generateDataSets = (fireNumber: number, currentAge: number, retirementAge:
             const yearsElapsed = date.diff(today, 'years').years
             const dataPoint = {
                 x: dateStr,
-                y: futureValueSeries(pmtMonthlyToDaily(monthlyContribution), rate, 365, yearsElapsed, principal)
+                y: futureValueSeries(pmtMonthlyToDaily(pmtMonthly), rate, 365, yearsElapsed, principal)
             }
             data.preCoastData.push(dataPoint)
         }
@@ -221,7 +225,7 @@ const generateDataSets = (fireNumber: number, currentAge: number, retirementAge:
             const yearsElapsed = date.diff(today, 'years').years
             const dataPoint = {
                 x: dateStr,
-                y: futureValueSeries(pmtMonthlyToDaily(monthlyContribution), rate, 365, yearsElapsed, principal)
+                y: futureValueSeries(pmtMonthlyToDaily(pmtMonthly), rate, 365, yearsElapsed, principal)
             }
             data.preCoastData.push(dataPoint)
         }
@@ -230,7 +234,7 @@ const generateDataSets = (fireNumber: number, currentAge: number, retirementAge:
             const dataPoint = {
                 x: dateStr,
                 // note: do not use result.coastFireDate because there would be a gap in the graph
-                y: futureValue(data.preCoastData[data.preCoastData.length - 1].y, rate, 365, yearsElapsed)
+                y: futureValueSeries(pmtMonthlyToDaily(pmtMonthlyBarista), rate, 365, yearsElapsed, data.preCoastData[data.preCoastData.length - 1].y)
             }
             data.postCoastData.push(dataPoint)
         }
@@ -245,7 +249,8 @@ const generateDataSets = (fireNumber: number, currentAge: number, retirementAge:
             const dataPoint = {
                 x: dateStr,
                 // note: do not use result.coastFireDate because there would be a gap in the graph
-                y: futureValue(principal, rate, 365, yearsElapsed)
+                // y: futureValue(principal, rate, 365, yearsElapsed)
+                y: futureValueSeries(pmtMonthlyToDaily(pmtMonthlyBarista), rate, 365, yearsElapsed, principal)
             }
             data.postCoastData.push(dataPoint)
         }


### PR DESCRIPTION
Add an additional option to specify small retirement contributions past the "primary" accumulation phase/period.

Note: I actually don't think this covers all 'barista FIRE' situations. 

In fact, I think a traditional barista FIRE scheme can be framed as achieving coast fire but then having a negative monthly "pmt" during the coasting phase. Those early withdrawals would be smaller than FIRE withdrawals, such that the stunted growth rate during barista/coasting phase is still high enough for a given nest egg to reach the FIRE number in time. 

As follow-up, we should allow negative values for monthly contributions during the barista FIRE period. With this, a person should be able to either withdraw money or stash a bit of money during their barista phase.